### PR TITLE
fix: handle with `Syntax.Str`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const PERIODS = ['.', '。'] as const
 const report: TextlintRuleModule<Options> = (context, _options = {}) => {
   const { Syntax, RuleError, report, fixer, getSource, locator } = context
   return {
-    [Syntax.Paragraph](node) {
+    [Syntax.Str](node) {
       const text = getSource(node)
       const period = PERIODS.find(period => text.endsWith(period))
       if (period) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/textlint-rule-no-period-on-paragraph-end/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
